### PR TITLE
Feature/chaining

### DIFF
--- a/example/src/main/kotlin/Main.kt
+++ b/example/src/main/kotlin/Main.kt
@@ -2,6 +2,7 @@ import org.postgresql.ds.PGPoolingDataSource
 import org.schedo.retry.RetryPolicy
 import org.schedo.scheduler.Scheduler
 import org.schedo.scheduler.SchedulerBuilder
+import org.schedo.task.SequenceBuilder
 import org.schedo.task.TaskBuilder
 import java.time.Duration
 import kotlin.random.Random
@@ -81,12 +82,10 @@ fun main() {
         println("Step Three")
     }.build()
 
-    val oneTwo = stepOne.andThen(stepTwo)
-    val oneTwoThree = stepOne.andThen(stepTwo).andThen(stepThree)
-    val oneTwoOrThree = stepOne.fold(stepTwo, stepThree)
+    val oneTwo = SequenceBuilder("oneTwo", stepOne).andThen(stepTwo).build()
+    val oneTwoThree = SequenceBuilder("oneTwoThree", stepOne).andThen(stepTwo).andThen(stepThree).build()
 
-    //scheduler.scheduleRecurring(oneTwo, Duration.ofSeconds(1))
-    scheduler.scheduleRecurring(oneTwoThree, Duration.ofSeconds(1))
+    scheduler.scheduleRecurring(oneTwo, Duration.ofSeconds(1))
     //scheduler.scheduleRecurring(oneTwoThree, Duration.ofSeconds(1))
 
     scheduler.start()

--- a/example/src/main/kotlin/Main.kt
+++ b/example/src/main/kotlin/Main.kt
@@ -85,8 +85,8 @@ fun main() {
     val oneTwo = SequenceBuilder("oneTwo", stepOne).andThen(stepTwo).build()
     val oneTwoThree = SequenceBuilder("oneTwoThree", stepOne).andThen(stepTwo).andThen(stepThree).build()
 
-    scheduler.scheduleRecurring(oneTwo, Duration.ofSeconds(1))
-    //scheduler.scheduleRecurring(oneTwoThree, Duration.ofSeconds(1))
+    //scheduler.scheduleRecurring(oneTwo, Duration.ofSeconds(1))
+    scheduler.scheduleRecurring(oneTwoThree, Duration.ofSeconds(1))
 
     scheduler.start()
     Thread.sleep(10 * 1000)

--- a/lib/src/main/kotlin/org/schedo/manager/TaskManager.kt
+++ b/lib/src/main/kotlin/org/schedo/manager/TaskManager.kt
@@ -88,6 +88,10 @@ class TaskManager(
         schedule(task.name, moment, firstInstanceID)
     }
 
+    fun register(task: Task) {
+        taskResolver.addTask(task)
+    }
+
     /**
      * Returns a number of fails after last success.
      * Note that setting [limit] to zero will result in zero return value,

--- a/lib/src/main/kotlin/org/schedo/task/Task.kt
+++ b/lib/src/main/kotlin/org/schedo/task/Task.kt
@@ -28,12 +28,12 @@ abstract class Task(
     /**
      * Called if task execution is successful
      */
-    protected abstract fun onCompleted(taskManager: TaskManager)
+    abstract fun onCompleted(taskManager: TaskManager)
 
     /**
      * Called if task execution throws an exception
      */
-    protected fun onFailed(e: Exception, taskManager: TaskManager) {
+    open fun onFailed(e: Exception, taskManager: TaskManager) {
         if (retryPolicy != null) {
             val failedCount = taskManager.failedCount(name, retryPolicy.maxRetries)
             val delay = retryPolicy.getNextDelay(failedCount)

--- a/lib/src/main/kotlin/org/schedo/task/Task.kt
+++ b/lib/src/main/kotlin/org/schedo/task/Task.kt
@@ -18,7 +18,7 @@ value class TaskName(val value: String)
  */
 abstract class Task(
     val name: TaskName,
-    private val retryPolicy: RetryPolicy? = null,
+    val retryPolicy: RetryPolicy? = null,
 ) {
     /**
      * Payload

--- a/lib/src/main/kotlin/org/schedo/task/TaskBuilder.kt
+++ b/lib/src/main/kotlin/org/schedo/task/TaskBuilder.kt
@@ -1,0 +1,101 @@
+package org.schedo.task
+
+import org.schedo.manager.TaskManager
+import org.schedo.retry.RetryPolicy
+
+abstract class CustomTask (
+    name: TaskName,
+    val retryPolicy: RetryPolicy? = null,
+    val dependencies: List<CustomTask> = emptyList(),
+) : Task(name, retryPolicy) {
+    fun andThen(next: CustomTask): CustomTask {
+        val parent = this
+        val composedName = TaskName("${name.value}_andThen_${next.name.value}")
+
+        return object : CustomTask(composedName, retryPolicy, dependencies + next) {
+            override fun run() = parent.run()
+
+            override fun onCompleted(taskManager: TaskManager) {
+                parent.onCompleted(taskManager)
+                val now = taskManager.dateTimeService.now()
+                taskManager.schedule(next.name, now)
+            }
+
+            override fun onFailed(e: Exception, taskManager: TaskManager) {
+                parent.onFailed(e, taskManager)
+                super.onFailed(e, taskManager) // handle retry
+            }
+        }
+    }
+
+    fun orElse(next: CustomTask): CustomTask {
+        val parent = this
+        val composedName = TaskName("${name.value}_orElse_${next.name.value}")
+
+        return object : CustomTask(composedName, retryPolicy, dependencies + next) {
+            override fun run() = parent.run()
+
+            override fun onCompleted(taskManager: TaskManager) {
+                parent.onCompleted(taskManager)
+            }
+
+            override fun onFailed(e: Exception, taskManager: TaskManager) {
+                parent.onFailed(e, taskManager)
+                // Note: no attempt of retry
+                val now = taskManager.dateTimeService.now()
+                taskManager.schedule(next.name, now)
+            }
+        }
+    }
+
+    fun fold(success: CustomTask, failure: CustomTask): CustomTask {
+        val parent = this
+        val composedName = TaskName("${name.value}_fold_${success.name.value}_${failure.name.value}")
+
+        return object : CustomTask(composedName, retryPolicy, dependencies + success + failure) {
+            override fun run() = parent.run()
+
+            override fun onCompleted(taskManager: TaskManager) {
+                parent.onCompleted(taskManager)
+                val now = taskManager.dateTimeService.now()
+                taskManager.schedule(success.name, now)
+            }
+
+            override fun onFailed(e: Exception, taskManager: TaskManager) {
+                parent.onFailed(e, taskManager)
+                // Note: no attempt of retry
+                val now = taskManager.dateTimeService.now()
+                taskManager.schedule(failure.name, now)
+            }
+        }
+    }
+}
+
+class TaskBuilder(val name: String, val func: () -> Unit) {
+    var retryPolicy: RetryPolicy? = null
+    var onCompletedHandler: (TaskManager) -> Unit = {_ -> }
+    var onFailedHandler: (e: Exception, taskManager: TaskManager) -> Unit = { _, _ -> }
+
+    fun retryPolicy(retryPolicy: RetryPolicy): TaskBuilder {
+        this.retryPolicy = retryPolicy
+        return this
+    }
+
+    fun onCompletedHandler(onCompletedHandler: (TaskManager) -> Unit): TaskBuilder {
+        this.onCompletedHandler = onCompletedHandler
+        return this
+    }
+
+    fun onFailedHandler(onFailedHandler: (Exception, taskManager: TaskManager) -> Unit): TaskBuilder {
+        this.onFailedHandler = onFailedHandler
+        return this
+    }
+
+    fun build(): CustomTask {
+        return object : CustomTask(TaskName(name), retryPolicy) {
+            override fun run() =  func()
+            override fun onCompleted(taskManager: TaskManager) = onCompletedHandler(taskManager)
+            override fun onFailed(e: Exception, taskManager: TaskManager) = onFailedHandler(e, taskManager)
+        }
+    }
+}


### PR DESCRIPTION
Пока код отвратительный и в таком виде я его точно пушить не хочу.
Хотелось бы, иметь следующий интерфейс:

Создание Step:
```
val stepOne = StepBuilder("stepOne"){
        val r = Random.nextInt(0, 3)
        if (r == 0) {
            println("Step One Failed")
            throw RuntimeException("Step one Failed")
        } else {
            println("Step One")
        }
```
Сейчас Step - это `Task`

После этого хотелось бы мочь переиспользовать этот step в разных цепочках (сейчас можно только в одной, но в коде нет никакой проверки на неправильное использование):
```
val oneTwo = SequenceBuilder("oneTwo", stepOne).andThen(stepTwo).build()
val oneTwoThree = SequenceBuilder("oneTwoThree", stepOne).andThen(stepTwo).andThen(stepThree).build()
```
Ну или сделать так, чтобы можно было только в одной - но тогда было бы здорово, чтобы `SequenceBuilder` поглощал step, как `std::move` в плюсах, но я не знаю аналога в Kotlin

После этого хотелось бы мочь запланировать sequence либо одноразово, либо recurring.
Чтобы этого добиться я соответствующе планирую голову цепочки. То есть в случае recurring цепочки первая таска перепланируется раз во сколько-то и заново начинает всю цепочку.

Я не знаю, какого типа сделать Step. С одной стороны `Task` удобно - готовые шаги я сохраняю в `dependencies`цепочки, а потом при планировании цепочки прохожусь по ним всем и добавляю в `taskResolver`. С другой стороны, каждый раз линковке задач, я создаю новый объект `Task` и переопределяю все методы, чтобы добавить к одному из них планирование следующей задачи.

В предпоследнем коммите я попыталась сделать переиспользование шагов в разных цепочка путём создания в каждой цепочке своей задачи - sequenceName + stepName. Но тогда всё перепланирование ломается - step запомнил onFailed хендлере, что ему нужно перепланировать именно stepName.

Я думала над тем, чтобы запретить Step'у иметь retry, а также хендлеры `onCompleted` и `onFailed`. То есть чтобы пользователь мог задать только тело шага. Зачем нужен `onCompleted`, если пользователь и так указывает `andThen` в цепочке? Свои ретраи у каждого шага при этом имеют смысл - например если хотим, чтобы шаг1 ретраился, а шаг2 - нет. Но возникает возможность задать политику ретраев у `stepOne`, а потом написать `stepOne.orElse(stepTwo)`. Мне интуитивно, что `stepTwo` выполнится не больше одного раза - 1, если `stepOne` упадёт; иначе 0. Но одновременно c ретраями `stepTwo` будет планироваться при каждом падении. Поэтому можно запретить retry у отдельных шагов и сделать это параметром цепочки, и из цепочки ретраить те шаги, после которых идёт andThen, а не обработчик падения.

Также мне не нравится, что в `stepOne.andThen(stepTwo).orElse(stepThree)` у меня `stepThree` запуститься только если упадёт `stepTwo`, а обычно если хоть что-то до stepThree упадёт

Текущая реализация сильно завязана на том, что цепочка линейная и имеет всегда один конец.
Операцию `stepOne.fold(stepOnSuccess, stepOnFailure)` можно будет реалзовать создав пустой `stepMerge`, который планируют после себя и `stepOnSuccess`, и `stepOnFailure` - так в цепочке до сих пор один конец