### PR TITLE
feature/waitwake

### DIFF
--- a/example/src/main/kotlin/Main.kt
+++ b/example/src/main/kotlin/Main.kt
@@ -2,6 +2,7 @@ import org.postgresql.ds.PGPoolingDataSource
 import org.schedo.retry.RetryPolicy
 import org.schedo.scheduler.Scheduler
 import org.schedo.scheduler.SchedulerBuilder
+import java.lang.Thread.sleep
 import java.time.Duration
 
 fun basicExample(scheduler: Scheduler) {
@@ -47,14 +48,24 @@ fun main() {
         }
 
     val scheduler = SchedulerBuilder()
-        .dataSource(source)
+        //.dataSource(source)
+        .executionThreads(2)
+        .pollingInterval(Duration.ofMillis(100))
         .build()
 
     scheduler.scheduleRecurring("CronRecurring", "*/2 * * * * ?"){
         println("Hello cron world")
     }
+    for (i in 1..10) {
+        val millis = 10 * i.toLong()
+        for (j in 1..10) {
+            scheduler.scheduleRecurring("recurring$i/$j", Duration.ofMillis(millis)){
+                sleep(millis)
+            }
+        }
+    }
 
     scheduler.start()
-    Thread.sleep(10 * 1000)
+    Thread.sleep(5 * 1000)
     scheduler.stop()
 }

--- a/lib/src/main/kotlin/org/schedo/waiter/Waiter.kt
+++ b/lib/src/main/kotlin/org/schedo/waiter/Waiter.kt
@@ -1,0 +1,59 @@
+package org.schedo.waiter
+
+import org.schedo.util.DateTimeService
+import org.schedo.util.DefaultDateTimeService
+import java.lang.Thread.sleep
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Thread that picks tasks from the taskRepository should wait in two scenarios:
+ * 1) There are no tasks to execute - wake up with polling interval [duration]
+ * 2) All executor threads are busy - should be woken up by executor when most of the tasks are completed
+ * The second also guarantees even workload on different servers
+ */
+class Waiter(
+    private val threadsCount: Int,
+    private val pollingInterval: Duration = Duration.ZERO,
+    private val busyRatio: Double = 2.7,
+) {
+    private val monitor = Object()
+    private var busy: Boolean = false
+
+    fun isBusy(executions: AtomicInteger): Boolean {
+        return executions.toDouble() / threadsCount > busyRatio
+    }
+
+    fun sleepPollingInterval() {
+        sleep(pollingInterval.toMillis())
+    }
+
+    fun waitLightLoad(executions: AtomicInteger) {
+        // May have missed wakePoller from executor => check isBusy(executions) once again
+        synchronized(monitor) {
+            busy = true
+            if (isBusy(executions)) {
+                while (busy) {
+                    monitor.wait()
+                }
+            } else {
+                busy = false
+            }
+        }
+    }
+
+    /**
+     * busy = true <-> maybe sleeping
+     * busy = false <-> surely awake
+     */
+    fun wakePoller() {
+        synchronized(monitor) {
+            val needNotify = busy
+            busy = false
+            if (needNotify) {
+                monitor.notify()
+            }
+        }
+        println()
+    }
+}

--- a/lib/src/main/kotlin/org/schedo/waiter/Waiter.kt
+++ b/lib/src/main/kotlin/org/schedo/waiter/Waiter.kt
@@ -18,6 +18,7 @@ class Waiter(
     private val busyRatio: Double = 2.7,
 ) {
     private val monitor = Object()
+    @Volatile
     private var busy: Boolean = false
 
     fun isBusy(executions: AtomicInteger): Boolean {
@@ -47,13 +48,13 @@ class Waiter(
      * busy = false <-> surely awake
      */
     fun wakePoller() {
-        synchronized(monitor) {
-            val needNotify = busy
-            busy = false
-            if (needNotify) {
+        if (busy) {
+            // avoid synchronized if possible
+            synchronized(monitor) {
+                busy = false
                 monitor.notify()
             }
+            println()
         }
-        println()
     }
 }


### PR DESCRIPTION
Поток, который в цикле забирал задачи из таблицы теперь иногда засыпает:
1) если нет задач засыпает на pollingInterval
2) если все воркеры заняты, то засыпает, чтобы им не мешать. Если задач осталось мало, то воркеры его будят обратно. Минус - если задач осталось мало, что все воркеры захватывают мьютекс (`synchronized(monitor)`), и этим самым уменьшают throughput